### PR TITLE
fix for extension in language_info dictionary

### DIFF
--- a/stata_kernel/stata_kernel.py
+++ b/stata_kernel/stata_kernel.py
@@ -21,7 +21,7 @@ class StataKernel(Kernel):
     language_info = {
         'name': 'stata',
         'mimetype': 'text/x-stata',
-        'file_extension': 'do',
+        'file_extension': '.do',
     }
     
     log_address = os.path.join(tempfile.gettempdir(), 'stata_kernel_log.txt')


### PR DESCRIPTION
changed extension from 'do' to '.do' so that the file>download as> stata option works. was not working without the dot.